### PR TITLE
Add support for in-memory database

### DIFF
--- a/spatia-room/src/main/java/co/anbora/labs/spatia/builder/SpatiaBuilder.kt
+++ b/spatia-room/src/main/java/co/anbora/labs/spatia/builder/SpatiaBuilder.kt
@@ -11,16 +11,20 @@ import java.util.concurrent.Executor
 class SpatiaBuilder<T : RoomDatabase> (
     context: Context,
     klass: Class<T>,
-    name: String
+    name: String?
 ): SpatiaRoom.Builder<T> {
 
     private val templateDb = "spatia_db_template.sqlite"
 
-    private val roomBuilder = Room.databaseBuilder(
-        context.applicationContext,
-        klass,
-        name
-    ).createFromAsset(templateDb)
+    private val roomBuilder = if (name != null) {
+        Room.databaseBuilder(
+            context.applicationContext,
+            klass,
+            name
+        )
+    } else {
+        Room.inMemoryDatabaseBuilder(context.applicationContext, klass)
+    }.createFromAsset(templateDb)
         .openHelperFactory(SpatiaHelperFactory())
 
     override fun createFromAsset(databaseFilePath: String): SpatiaRoom.Builder<T> {

--- a/spatia-room/src/main/java/co/anbora/labs/spatia/builder/SpatiaBuilder.kt
+++ b/spatia-room/src/main/java/co/anbora/labs/spatia/builder/SpatiaBuilder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import co.anbora.labs.spatia.db.SpatiaHelperFactory
 import java.util.concurrent.Executor
@@ -24,8 +25,11 @@ class SpatiaBuilder<T : RoomDatabase> (
         )
     } else {
         Room.inMemoryDatabaseBuilder(context.applicationContext, klass)
-    }.createFromAsset(templateDb)
-        .openHelperFactory(SpatiaHelperFactory())
+    }.addCallback(object : RoomDatabase.Callback() {
+        override fun onCreate(db: SupportSQLiteDatabase) {
+            db.query("SELECT InitSpatialMetaData();").moveToNext()
+        }
+    }).openHelperFactory(SpatiaHelperFactory())
 
     override fun createFromAsset(databaseFilePath: String): SpatiaRoom.Builder<T> {
         roomBuilder.createFromAsset(databaseFilePath)

--- a/spatia-room/src/main/java/co/anbora/labs/spatia/builder/SpatiaRoom.kt
+++ b/spatia-room/src/main/java/co/anbora/labs/spatia/builder/SpatiaRoom.kt
@@ -27,6 +27,16 @@ object SpatiaRoom {
         )
     }
 
+    fun <T : RoomDatabase> inMemoryDatabaseBuilder(
+        context: Context, klass: Class<T>
+    ): Builder<T> {
+        return SpatiaBuilder(
+            context.applicationContext,
+            klass,
+            null
+        )
+    }
+
     /**
      * Builder for SpatiaDatabase.
      *

--- a/spatia-room/src/main/java/co/anbora/labs/spatia/db/Helper.kt
+++ b/spatia-room/src/main/java/co/anbora/labs/spatia/db/Helper.kt
@@ -8,7 +8,7 @@ import org.spatialite.database.SQLiteOpenHelper
 
 class Helper(
     private val context: Context,
-    private val dbName: String,
+    private val dbName: String?,
     private val callback: SupportSQLiteOpenHelper.Callback
 ): SupportSQLiteOpenHelper {
 

--- a/spatia-room/src/main/java/co/anbora/labs/spatia/db/SpatiaHelperFactory.kt
+++ b/spatia-room/src/main/java/co/anbora/labs/spatia/db/SpatiaHelperFactory.kt
@@ -5,14 +5,11 @@ import androidx.sqlite.db.SupportSQLiteOpenHelper
 
 class SpatiaHelperFactory: SupportSQLiteOpenHelper.Factory {
     override fun create(configuration: SupportSQLiteOpenHelper.Configuration): SupportSQLiteOpenHelper {
-        require(configuration.name != null) {
-            "Name database null"
-        }
-        return create(configuration.context, configuration.name as String, configuration.callback)
+        return create(configuration.context, configuration.name, configuration.callback)
     }
 
     private fun create(
-        context: Context, name: String,
+        context: Context, name: String?,
         callback: SupportSQLiteOpenHelper.Callback
     ): SupportSQLiteOpenHelper {
         return Helper(context, name, callback)


### PR DESCRIPTION
E.g. for unit testing purposes it is often useful to be able to create an in-memory database with [`Room.inMemoryDatabaseBuilder`](https://developer.android.com/reference/androidx/room/Room#inMemoryDatabaseBuilder(android.content.Context,java.lang.Class)). This PR adds a corresponding `SpatiaRoom.inMemoryDatabaseBuilder` function for doing the same with spatia-room.

Apparently in-memory databases cannot be created from an asset, so I needed to remove `createFromAsset(templateDb)` call and the `spatia_db_template.sqlite` file. Instead, I added a callback that calls `SELECT InitSpatialMetaData();` to initialize the database, which should have the same effect (right?) and also removes the need for shipping this extra 5 MB file with the app.